### PR TITLE
Add USD scene builder from JSON template

### DIFF
--- a/usd_scene_init/src/usd_scene_init/create_scene_from_template.py
+++ b/usd_scene_init/src/usd_scene_init/create_scene_from_template.py
@@ -1,0 +1,25 @@
+import argparse
+from usd_scene_init import utils
+from pathlib import Path
+
+_THIS = Path(__file__)
+
+TEMPLATE_PATH = _THIS.parent.joinpath("init_scene_template.json")
+DEFAULT_OUTPUT_PATH = "./template_scene1.usda"
+
+
+def main(args: list[str] | None = None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--template-path", default=TEMPLATE_PATH)
+    parser.add_argument("--output-path", default=DEFAULT_OUTPUT_PATH)
+
+    namespace = parser.parse_args(args)
+
+    utils.create_scene_from_json(
+        namespace.template_path,
+        namespace.output_path,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/usd_scene_init/src/usd_scene_init/init_scene_template.json
+++ b/usd_scene_init/src/usd_scene_init/init_scene_template.json
@@ -1,0 +1,55 @@
+{
+    "name": "main",
+    "type": "Scope",
+    "children": [
+        {
+            "name": "ASSETS",
+            "type": "Scope",
+            "children": [
+                {
+                    "name": "Cre",
+                    "type": "Scope",
+                    "children": []
+                },
+                {
+                    "name": "Env",
+                    "type": "Scope",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "name": "SHOT",
+            "type": "Scope",
+            "children": [
+                {
+                    "name": "Env",
+                    "type": "Xform",
+                    "children": [
+                        {
+                            "name": "geom",
+                            "type": "Xform"
+                        },
+                        {
+                            "name": "dressing",
+                            "type": "Xform"
+                        }
+                    ]
+                },
+                 {
+                    "name": "cameras",
+                    "type": "Xform",
+                    "children": []
+                 },
+                {
+                    "name": "lights",
+                    "type": "Xform",
+                    "children": []
+                }
+            ]
+        }
+
+
+
+    ]
+}

--- a/usd_scene_init/src/usd_scene_init/utils.py
+++ b/usd_scene_init/src/usd_scene_init/utils.py
@@ -1,0 +1,37 @@
+import json
+from typing import Any
+from pxr import Usd, UsdGeom
+
+
+# USD Scene Initialization From Template
+def configure_xform(prim: Usd.Prim, kind: str | None = None):
+    xform = UsdGeom.Xform(prim)
+    if kind:
+        model_api = Usd.ModelAPI(xform)
+        model_api.SetKind(kind)
+        model_api.SetAssetName(prim.GetName())
+
+    return xform
+
+
+def create_prim(stage: Usd.Stage, parent_path: str, prim: dict[str, Any]):
+    path = f"{parent_path}/{prim['name']}"
+    prim_type = prim["type"]
+    prim_kind = prim.get("kind")
+
+    usd_prim = stage.DefinePrim(path, prim_type)
+
+    if usd_prim.IsA(UsdGeom.Xform):
+        configure_xform(usd_prim, prim_kind)
+
+    for child in prim.get("children", []):
+        create_prim(stage, path, child)
+
+
+def create_scene_from_json(template_path: str, stage_output_path: str):
+    with open(template_path, "r") as f:
+        root_prim = json.load(f)
+
+    stage = Usd.Stage.CreateNew(stage_output_path)
+    create_prim(stage, "", root_prim)
+    stage.GetRootLayer().Save()


### PR DESCRIPTION
Implements recursive scene construction from a structured JSON file Supports prim types like Xform, Scope, and Camera
Applies optional 'kind' metadata via ModelAPI for Xforms Includes basic CLI interface using argparse with default paths