### PR TITLE
Usd stage qc: New feature - bulk assign materials to all filtered primitives

### DIFF
--- a/usd_stage_qc/src/usd_stage_qc/_houdini.py
+++ b/usd_stage_qc/src/usd_stage_qc/_houdini.py
@@ -1,4 +1,5 @@
 import hou
+from pxr import Usd
 import os
 from usd_stage_qc import _status_messages
 
@@ -57,7 +58,13 @@ def offset_outputs_position(root):
         for node in current.outputs():
             queue.append(node)
 
-def compute_mat_assign_index(material_assign_node):
+
+def compute_mat_assign_index(material_assign_node: hou.node):
+    """
+    Computes the next material assignment index.
+    If there is only one material and its path is empty, returns the current index.
+    Otherwise, increments the current material count by 1 and returns it.
+    """
     mat_num = material_assign_node.parm("nummaterials").eval()
 
     if mat_num <= 1 and material_assign_node.parm(f"matspecpath{mat_num}").eval() == '':
@@ -66,8 +73,12 @@ def compute_mat_assign_index(material_assign_node):
         new_mat_index = mat_num + 1
     return new_mat_index
 
-def populate_mat_assign_parms(material_assign_node, mat_index, usd_prim, material_prim):
+
+def populate_mat_assign_parms(material_assign_node: hou.node, mat_index: int, usd_prim: Usd.Prim,
+                              material_prim: Usd.Prim):
+    """
+    Populates the material assignment parameters for a new material entry.
+    """
     material_assign_node.parm("nummaterials").set(mat_index)
     material_assign_node.parm(f"primpattern{mat_index}").set(str(usd_prim.GetPath()))
     material_assign_node.parm(f"matspecpath{mat_index}").set(str(material_prim.GetPath()))
-

--- a/usd_stage_qc/src/usd_stage_qc/_houdini.py
+++ b/usd_stage_qc/src/usd_stage_qc/_houdini.py
@@ -19,7 +19,7 @@ def get_single_selected_node():
     return selected[0]
 
 
-def create_and_insert_hou_node(parent_node: hou.node, type: str, name: str):
+def create_and_insert_hou_node(parent_node: hou.Node, type: str, name: str):
     """
     Creates and inserts a node as an output of the parent_node into a current nodes stream,
     Returns: created and inserted node
@@ -59,7 +59,7 @@ def offset_outputs_position(root):
             queue.append(node)
 
 
-def compute_mat_assign_index(material_assign_node: hou.node):
+def compute_mat_assign_index(material_assign_node: hou.Node):
     """
     Computes the next material assignment index.
     If there is only one material and its path is empty, returns the current index.
@@ -74,7 +74,7 @@ def compute_mat_assign_index(material_assign_node: hou.node):
     return new_mat_index
 
 
-def populate_mat_assign_parms(material_assign_node: hou.node, mat_index: int, usd_prim: Usd.Prim,
+def populate_mat_assign_parms(material_assign_node: hou.Node, mat_index: int, usd_prim: Usd.Prim,
                               material_prim: Usd.Prim):
     """
     Populates the material assignment parameters for a new material entry.

--- a/usd_stage_qc/src/usd_stage_qc/_houdini.py
+++ b/usd_stage_qc/src/usd_stage_qc/_houdini.py
@@ -56,3 +56,18 @@ def offset_outputs_position(root):
 
         for node in current.outputs():
             queue.append(node)
+
+def compute_mat_assign_index(material_assign_node):
+    mat_num = material_assign_node.parm("nummaterials").eval()
+
+    if mat_num <= 1 and material_assign_node.parm(f"matspecpath{mat_num}").eval() == '':
+        new_mat_index = mat_num
+    else:
+        new_mat_index = mat_num + 1
+    return new_mat_index
+
+def populate_mat_assign_parms(material_assign_node, mat_index, usd_prim, material_prim):
+    material_assign_node.parm("nummaterials").set(mat_index)
+    material_assign_node.parm(f"primpattern{mat_index}").set(str(usd_prim.GetPath()))
+    material_assign_node.parm(f"matspecpath{mat_index}").set(str(material_prim.GetPath()))
+

--- a/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
+++ b/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
@@ -117,6 +117,11 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         self.tree_mat_list.setHeaderLabels(["Material libreris"])
 
         self.assign_layout.addWidget(self.tree_mat_list)
+
+        # Add Bulk Assing QCheckBox
+        self.bulk_assign_check =QtWidgets.QCheckBox("Bulk assign to all filtered primitives")
+        self.assign_layout.addWidget(self.bulk_assign_check)
+        
         # Add Assigne Material button
         self.assign_mat_btn = QtWidgets.QPushButton("Assign")
         self.assign_layout.addWidget(self.assign_mat_btn)
@@ -279,9 +284,16 @@ class MaterialBindingChecker(QtWidgets.QDialog):
             if self.assign_mat_node is None:
                 _status_messages.handle_error("Failed to create the Assign Material node. "
                                               "Ensure you are in a writable context.")
-
+        # Bulk Assign selected material to all filtered assets
+        if self.bulk_assign_check.isChecked():
+            selected_items = [
+                self.search_output.item(i)
+                for i in range(self.search_output.count())
+                if not self.search_output.item(i).isHidden()
+            ]
         # Get the selection list
-        selected_items = self.get_selection(self.search_output)
+        else:
+            selected_items = self.get_selection(self.search_output)
 
         if selected_items is not None:
             for item in selected_items:
@@ -351,9 +363,7 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         for index in range(self.search_output.count()):
             item = self.search_output.item(index)
 
-            print(item)
-            if item.text().lower() in search_results:
-                print(f"match found: {search_results} is {item.text().lower()}")
+
             if item.text().lower() in search_results or self.search_line.text() == '':
                 item.setHidden(False)
             else:

--- a/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
+++ b/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
@@ -284,16 +284,11 @@ class MaterialBindingChecker(QtWidgets.QDialog):
                     _status_messages.handle_error("Failed to create the Assign Material node. "
                                                   "Ensure you are in a writable context.")
 
-            mat_num = self.assign_mat_node.parm("nummaterials").eval()
 
-            if mat_num <= 1 and self.assign_mat_node.parm(f"matspecpath{mat_num}").eval() == '':
-                new_mat_index = mat_num
-            else:
-                new_mat_index = mat_num + 1
+            #Get material index and populate assigne material paramenters
+            new_mat_index =_houdini.compute_mat_assign_index(self.assign_mat_node)
+            _houdini.populate_mat_assign_parms(self.assign_mat_node, new_mat_index, usd_prim, material_prim)
 
-            self.assign_mat_node.parm("nummaterials").set(new_mat_index)
-            self.assign_mat_node.parm(f"primpattern{new_mat_index}").set(str(usd_prim.GetPath()))
-            self.assign_mat_node.parm(f"matspecpath{new_mat_index}").set(str(material_prim.GetPath()))
             self.prim_bound_path.setText(str(material_prim.GetPath()))
         else:
             _status_messages.handle_error("No material selected. "


### PR DESCRIPTION
Bulk assign to filtered primitives:
When the checkbox "Bulk assign material to all filtered" is enabled, the selected material is applied to all filtered primitives, regardless of manual selection. 

Functions compute_mat_assign_index and populate_mat_assign_parms were moved from the UI class to a dedicated _houdini module for better separation

get_selection was refactored to return a list, enabling multi-selection and material assignment across multiple primitives.

Added Docstrings and type hints
