### PR TITLE
Usd stage qc: Material Assignment Refactor & Material Status Display

### DIFF
--- a/usd_stage_qc/src/usd_stage_qc/_usd.py
+++ b/usd_stage_qc/src/usd_stage_qc/_usd.py
@@ -31,14 +31,14 @@ def collect_prims_without_material(stage: Usd.Stage) -> list[str]:
     for prim in iterator:
         if not iterator.IsPostVisit() and prim.IsA(UsdGeom.Imageable):
 
-            bound_material, strength = check_prim_material_binding(prim)
-            if not bound_material and prim.IsA(UsdGeom.Mesh):
-                no_material.append(prim)
-
+            bound_material, _ = check_prim_material_binding(prim)
+            if prim.IsA(UsdGeom.Mesh):
+                if not bound_material or not bound_material.GetPrim().IsActive():
+                    no_material.append(prim)
     return no_material
 
 
-def check_prim_material_binding(prim: Usd.Prim) ->  Tuple[Usd.Prim, UsdShade.Tokens]:
+def check_prim_material_binding(prim: Usd.Prim) -> Tuple[Usd.Prim, UsdShade.Tokens]:
     """
     Checks if a primitive has material binding
     """

--- a/usd_stage_qc/src/usd_stage_qc/_usd.py
+++ b/usd_stage_qc/src/usd_stage_qc/_usd.py
@@ -33,7 +33,7 @@ def collect_prims_without_material(stage: Usd.Stage) -> list[str]:
 
             bound_material, _ = check_prim_material_binding(prim)
             if prim.IsA(UsdGeom.Mesh):
-                if not bound_material or not bound_material.GetPrim().IsActive():
+                if not bound_material or not is_material_active(bound_material):
                     no_material.append(prim)
     return no_material
 
@@ -45,6 +45,24 @@ def check_prim_material_binding(prim: Usd.Prim) -> Tuple[Usd.Prim, UsdShade.Toke
     mat_bind_api = UsdShade.MaterialBindingAPI(prim)
     bound_material, strength = mat_bind_api.ComputeBoundMaterial()
     return bound_material, strength
+
+
+def is_material_active(mat: Usd.Prim) -> bool:
+    """
+    Checks if material is material.
+    """
+    return mat.GetPrim().IsActive()
+
+
+def solve_material_status(mat: Usd.Prim) -> str:
+    """
+    Returns material status string.
+    """
+    if mat is None:
+        return None
+    if not is_material_active(mat):
+        return "Deactivated"
+    return "Active"
 
 
 def check_live_houdini_stage(stage):

--- a/usd_stage_qc/src/usd_stage_qc/_usd.py
+++ b/usd_stage_qc/src/usd_stage_qc/_usd.py
@@ -33,7 +33,7 @@ def collect_prims_without_material(stage: Usd.Stage) -> list[str]:
 
             bound_material, _ = check_prim_material_binding(prim)
             if prim.IsA(UsdGeom.Mesh):
-                if not bound_material or not is_material_active(bound_material):
+                if not bound_material or not bound_material.GetPrim().IsActive():
                     no_material.append(prim)
     return no_material
 
@@ -45,24 +45,6 @@ def check_prim_material_binding(prim: Usd.Prim) -> Tuple[Usd.Prim, UsdShade.Toke
     mat_bind_api = UsdShade.MaterialBindingAPI(prim)
     bound_material, strength = mat_bind_api.ComputeBoundMaterial()
     return bound_material, strength
-
-
-def is_material_active(mat: Usd.Prim) -> bool:
-    """
-    Checks if material is material.
-    """
-    return mat.GetPrim().IsActive()
-
-
-def solve_material_status(mat: Usd.Prim) -> str:
-    """
-    Returns material status string.
-    """
-    if mat is None:
-        return None
-    if not is_material_active(mat):
-        return "Deactivated"
-    return "Active"
 
 
 def check_live_houdini_stage(stage):

--- a/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
+++ b/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
@@ -112,6 +112,11 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         self.assign_grp.setLayout(self.assign_layout)
         self.central_layout.addWidget(self.assign_grp)
 
+        # Add Expand all QCheck Box
+
+        self.expand_all_check = QtWidgets.QCheckBox("Expand All")
+        self.assign_layout.addWidget(self.expand_all_check)
+
         # Add Materials Tree View
 
         self.tree_mat_list = QtWidgets.QTreeWidget(self)
@@ -155,6 +160,7 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         self.refresh_btn.clicked.connect(self.on_refresh_executed)
         self.search_line.textEdited.connect(self.run_search)
         self.search_line.textChanged.connect(self.reset_search_state)
+        self.expand_all_check.toggled.connect(self.on_expand_all_check)
 
     def populate_prim_list(self):
         """
@@ -262,6 +268,15 @@ class MaterialBindingChecker(QtWidgets.QDialog):
             found.setData(0, QtCore.Qt.UserRole, metadata)
 
         self.build_tree_recursive(found, parts[1:], material_prim)
+
+    def on_expand_all_check(self):
+        """
+        Expands the material view tree when checked, collapses it when unchecked.
+        """
+        if self.expand_all_check.isChecked():
+            self.tree_mat_list.expandAll()
+        else:
+            self.tree_mat_list.collapseAll()
 
     def bind_material(self):
         """

--- a/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
+++ b/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
@@ -210,6 +210,7 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         """
         self.clear_details_view()
         self.populate_prim_list()
+        self.search_line.clear()
 
     def clear_details_view(self):
         self.prim_name_label.clear()

--- a/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
+++ b/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
@@ -93,6 +93,16 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         self.prim_type_label.setAlignment(QtCore.Qt.AlignLeft)
         self.frame_layout.addWidget(self.prim_type_label)
 
+        # Add Material Status Text Label
+
+        self.mat_status_text_label = QtWidgets.QLabel("Material Status:")
+        self.frame_layout.addWidget(self.mat_status_text_label)
+
+        # Add Material Status Label
+        self.mat_status_label = QtWidgets.QLabel()
+        self.mat_status_label.setAlignment(QtCore.Qt.AlignLeft)
+        self.frame_layout.addWidget(self.mat_status_label)
+
         # Add Prim Bound Label QLabel
         self.prim_bound_label = QtWidgets.QLabel("\nMaterial Bind:")
         self.prim_bound_label.setAlignment(QtCore.Qt.AlignLeft)
@@ -120,14 +130,14 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         # Add Materials Tree View
 
         self.tree_mat_list = QtWidgets.QTreeWidget(self)
-        self.tree_mat_list.setHeaderLabels(["Material libreris"])
+        self.tree_mat_list.setHeaderLabels(["Material Libraries"])
         self.assign_layout.addWidget(self.tree_mat_list)
 
-        # Add Bulk Assing QCheckBox
+        # Add Bulk Assign QCheckBox
         self.bulk_assign_check = QtWidgets.QCheckBox("Bulk assign to all filtered primitives")
         self.assign_layout.addWidget(self.bulk_assign_check)
 
-        # Add Assigne Material button
+        # Add Assign Material button
         self.assign_mat_btn = QtWidgets.QPushButton("Assign")
         self.assign_layout.addWidget(self.assign_mat_btn)
 
@@ -156,7 +166,7 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         # _____________________________
         # Buttons connections
         self.search_output.itemSelectionChanged.connect(self.on_list_item_changed)
-        self.assign_mat_btn.clicked.connect(self.bind_material)
+        self.assign_mat_btn.clicked.connect(self.on_assign_material_executed)
         self.refresh_btn.clicked.connect(self.on_refresh_executed)
         self.search_line.textEdited.connect(self.run_search)
         self.search_line.textChanged.connect(self.reset_search_state)
@@ -207,6 +217,9 @@ class MaterialBindingChecker(QtWidgets.QDialog):
             self.prim_path_text.setText(path)
             self.prim_type_label.setText(str(usd_prim.GetTypeName()))
             mat = _usd.check_prim_material_binding(usd_prim)[0]
+
+            self.mat_status_label.setText(
+                str(_usd.solve_material_status(mat))) if mat else self.mat_status_label.setText("None")
             self.prim_bound_path.setText(str(mat.GetPath())) if mat else self.prim_bound_path.setText('None')
 
     def on_refresh_executed(self):
@@ -222,8 +235,8 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         self.prim_name_label.clear()
         self.prim_path_text.clear()
         self.prim_type_label.clear()
+        self.mat_status_label.clear()
         self.prim_bound_path.clear()
-        print(f"Call clear detail view")
 
     def populate_material_tree(self):
         """
@@ -278,9 +291,14 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         else:
             self.tree_mat_list.collapseAll()
 
-    def bind_material(self):
+    def on_assign_material_executed(self):
         """
-        Binds the selected material to the selected prim.
+        Executes all logic to bind the selected material to one or more primitives.
+        Validates the selected material from the material library.
+        Creates an Assign Material node if one does not already exist.
+        Binds the material to selected primitives or all filtered primitives (if bulk assign is checked)
+        Updates the detail view data.
+
         """
         # Check if the selected material is valid and get its metadata
         selected_mat_item = self.get_selection(self.tree_mat_list)
@@ -295,20 +313,20 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         else:
             _status_messages.handle_error("No material selected. "
                                           "Please select a material from the material library.")
-            # Check if an Assign Material node already exists or needs to be created
+        # Check if an Assign Material node already exists or needs to be created
         if self.assign_mat_node is None:
             self.create_assign_material_node()
             if self.assign_mat_node is None:
                 _status_messages.handle_error("Failed to create the Assign Material node. "
                                               "Ensure you are in a writable context.")
-        # Bulk Assign selected material to all filtered assets
+        #  If Bulk Assign is checked, selected_items is set to all filtered primitives
         if self.bulk_assign_check.isChecked():
             selected_items = [
                 self.search_output.item(i)
                 for i in range(self.search_output.count())
                 if not self.search_output.item(i).isHidden()
             ]
-        # Get the selection list
+        # Get the selection list if bulk selection is not checked
         else:
             selected_items = self.get_selection(self.search_output)
 
@@ -325,8 +343,20 @@ class MaterialBindingChecker(QtWidgets.QDialog):
                 new_mat_index = _houdini.compute_mat_assign_index(self.assign_mat_node)
                 _houdini.populate_mat_assign_parms(self.assign_mat_node, new_mat_index, usd_prim, material_prim)
 
-                if self.get_selection(self.search_output):
-                    self.prim_bound_path.setText(str(material_prim.GetPath()))
+            # Set selection on the first visible item in a list if the bulk assign is checked
+            if self.bulk_assign_check.isChecked():
+                for i in range(self.search_output.count()):
+                    item = self.search_output.item(i)
+                    if not item.isHidden():
+                        self.search_output.setCurrentItem(item)
+                        item.setSelected(True)
+
+                        break
+            if self.get_selection(self.search_output):
+                self.mat_status_label.setText(str(_usd.solve_material_status(
+                    material_prim))) if material_prim else self.mat_status_label.setText("None")
+                self.prim_bound_path.setText(str(material_prim.GetPath()))
+            
         else:
             _status_messages.handle_error("No geometry selected. Please select a primitive from the list.")
             return
@@ -393,6 +423,7 @@ class MaterialBindingChecker(QtWidgets.QDialog):
     def reset_search_state(self, text):
         if not text:
             self.searching = False
+            self.search_output.clearSelection()
 
 
 dialog = None

--- a/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
+++ b/usd_stage_qc/src/usd_stage_qc/material_binding_validator_ui.py
@@ -93,6 +93,16 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         self.prim_type_label.setAlignment(QtCore.Qt.AlignLeft)
         self.frame_layout.addWidget(self.prim_type_label)
 
+        # Add Material Status Text Label
+
+        self.mat_status_text_label = QtWidgets.QLabel("Material Status:")
+        self.frame_layout.addWidget(self.mat_status_text_label)
+
+        # Add Material Status Label
+        self.mat_status_label = QtWidgets.QLabel()
+        self.mat_status_label.setAlignment(QtCore.Qt.AlignLeft)
+        self.frame_layout.addWidget(self.mat_status_label)
+
         # Add Prim Bound Label QLabel
         self.prim_bound_label = QtWidgets.QLabel("\nMaterial Bind:")
         self.prim_bound_label.setAlignment(QtCore.Qt.AlignLeft)
@@ -120,14 +130,14 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         # Add Materials Tree View
 
         self.tree_mat_list = QtWidgets.QTreeWidget(self)
-        self.tree_mat_list.setHeaderLabels(["Material libreris"])
+        self.tree_mat_list.setHeaderLabels(["Material Libraries"])
         self.assign_layout.addWidget(self.tree_mat_list)
 
-        # Add Bulk Assing QCheckBox
+        # Add Bulk Assign QCheckBox
         self.bulk_assign_check = QtWidgets.QCheckBox("Bulk assign to all filtered primitives")
         self.assign_layout.addWidget(self.bulk_assign_check)
 
-        # Add Assigne Material button
+        # Add Assign Material button
         self.assign_mat_btn = QtWidgets.QPushButton("Assign")
         self.assign_layout.addWidget(self.assign_mat_btn)
 
@@ -156,7 +166,7 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         # _____________________________
         # Buttons connections
         self.search_output.itemSelectionChanged.connect(self.on_list_item_changed)
-        self.assign_mat_btn.clicked.connect(self.bind_material)
+        self.assign_mat_btn.clicked.connect(self.on_assign_material_executed)
         self.refresh_btn.clicked.connect(self.on_refresh_executed)
         self.search_line.textEdited.connect(self.run_search)
         self.search_line.textChanged.connect(self.reset_search_state)
@@ -207,6 +217,9 @@ class MaterialBindingChecker(QtWidgets.QDialog):
             self.prim_path_text.setText(path)
             self.prim_type_label.setText(str(usd_prim.GetTypeName()))
             mat = _usd.check_prim_material_binding(usd_prim)[0]
+
+            self.mat_status_label.setText(
+                str(_usd.solve_material_status(mat))) if mat else self.mat_status_label.setText("None")
             self.prim_bound_path.setText(str(mat.GetPath())) if mat else self.prim_bound_path.setText('None')
 
     def on_refresh_executed(self):
@@ -222,8 +235,8 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         self.prim_name_label.clear()
         self.prim_path_text.clear()
         self.prim_type_label.clear()
+        self.mat_status_label.clear()
         self.prim_bound_path.clear()
-        print(f"Call clear detail view")
 
     def populate_material_tree(self):
         """
@@ -278,9 +291,14 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         else:
             self.tree_mat_list.collapseAll()
 
-    def bind_material(self):
+    def on_assign_material_executed(self):
         """
-        Binds the selected material to the selected prim.
+        Executes all logic to bind the selected material to one or more primitives.
+        Validates the selected material from the material library.
+        Creates an Assign Material node if one does not already exist.
+        Binds the material to selected primitives or all filtered primitives (if bulk assign is checked)
+        Updates the detail view data.
+
         """
         # Check if the selected material is valid and get its metadata
         selected_mat_item = self.get_selection(self.tree_mat_list)
@@ -295,20 +313,20 @@ class MaterialBindingChecker(QtWidgets.QDialog):
         else:
             _status_messages.handle_error("No material selected. "
                                           "Please select a material from the material library.")
-            # Check if an Assign Material node already exists or needs to be created
+        # Check if an Assign Material node already exists or needs to be created
         if self.assign_mat_node is None:
             self.create_assign_material_node()
             if self.assign_mat_node is None:
                 _status_messages.handle_error("Failed to create the Assign Material node. "
                                               "Ensure you are in a writable context.")
-        # Bulk Assign selected material to all filtered assets
+        #  If Bulk Assign is checked, selected_items is set to all filtered primitives
         if self.bulk_assign_check.isChecked():
             selected_items = [
                 self.search_output.item(i)
                 for i in range(self.search_output.count())
                 if not self.search_output.item(i).isHidden()
             ]
-        # Get the selection list
+        # Get the selection list if bulk selection is not checked
         else:
             selected_items = self.get_selection(self.search_output)
 
@@ -326,7 +344,19 @@ class MaterialBindingChecker(QtWidgets.QDialog):
                 _houdini.populate_mat_assign_parms(self.assign_mat_node, new_mat_index, usd_prim, material_prim)
 
                 if self.get_selection(self.search_output):
+                    self.mat_status_label.setText(str(_usd.solve_material_status(
+                        material_prim))) if material_prim else self.mat_status_label.setText("None")
                     self.prim_bound_path.setText(str(material_prim.GetPath()))
+
+        # Set selection on the first visible item in a list if the bulk assign is checked
+        if self.bulk_assign_check.isChecked():
+            for i in range(self.search_output.count()):
+                item = self.search_output.item(i)
+                if not item.isHidden():
+                    self.search_output.setCurrentItem(item)
+                    item.setSelected(True)
+                    break
+            self.select_first_visible_item(self.search_output)
         else:
             _status_messages.handle_error("No geometry selected. Please select a primitive from the list.")
             return
@@ -393,6 +423,7 @@ class MaterialBindingChecker(QtWidgets.QDialog):
     def reset_search_state(self, text):
         if not text:
             self.searching = False
+            self.search_output.clearSelection()
 
 
 dialog = None


### PR DESCRIPTION

Added is_material_active and solve_material_status functions to _usd.py to check if a bound material is active or deactivated.
Renamed bind_material to on_assign_material_executed and refactored all material assignment logic into this method.
Introduced a material status label in the detail view to provide visual feedback on material state.
Ensured the detail view is correctly updated after bulk material assignments.